### PR TITLE
Fix crashes in apps using Facebook login (Remove rule com.facebook.internal.FacebookInitProvider)

### DIFF
--- a/system/bin/dss
+++ b/system/bin/dss
@@ -89,7 +89,7 @@ for i in $PLIST; do
     dodis $CMD "$i/com.crashlytics.android.CrashlyticsInitProvider"
     dodis $CMD "$i/com.facebook.ads.internal.ipc.AdsMessengerService"
     dodis $CMD "$i/com.facebook.ads.internal.ipc.AdsProcessPriorityService"
-    dodis $CMD "$i/com.facebook.internal.FacebookInitProvider"
+    # # dodis $CMD "$i/com.facebook.internal.FacebookInitProvider"
     dodis $CMD "$i/com.google.analytics.tracking.android.CampaignTrackingReceiver"
     dodis $CMD "$i/com.google.analytics.tracking.android.CampaignTrackingService"
     dodis $CMD "$i/com.google.android.gms.ads.AdActivity"


### PR DESCRIPTION
Hello,
I have found that Disabling the Provider "com.facebook.internal.FacebookInitProvider" causes a few of applications that use Facebook as one of the login methods either to crash or fail to open the login screen.
So I would suggest to remove it from the rules.